### PR TITLE
Replace log with logrus

### DIFF
--- a/ultradns/common.go
+++ b/ultradns/common.go
@@ -3,7 +3,7 @@ package ultradns
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"

--- a/ultradns/config.go
+++ b/ultradns/config.go
@@ -2,7 +2,7 @@ package ultradns
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/ultradns/ultradns-sdk-go"
 )


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-ultradns', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
acceptence_test
scripts
.github
ultradns
website
.git
docs
r
objects
info
branches
logs
refs
hooks
97
b6
e6
fe
c5
1e
d0
1c
72
c8
59
87
ba
42
a3
6c
db
ea
76
43
ca
26
06
f3
0b
a6
74
93
d1
e9
pack
9a
be
info
f8
80
ed
3c
15
56
bc
0c
a8
67
3d
b9
84
33
38
32
cc
a1
25
6f
30
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)